### PR TITLE
feat: allow to specify environments to support with new envTargets option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Disable runtime transform. i.e. do not add helpers and polyfill for unsupported 
 
 As we're using `babel-plugin-transform-runtime` to polyfill your code without polluting globals, something like `"foobar".includes("foo")` will not work since that would require modification of existing builtins. See [babel-plugin-transform-runtime](https://www.npmjs.com/package/babel-plugin-transform-runtime).
 
-### envTargets
+### targets
 
 Type: `object`<br>
 Default: `{ ie: 9, uglify: true }`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Features
 
 - Latest ECMAScript features (babel-preset-env)
-- Object rest spread and dynamic import 
+- Object rest spread and dynamic import
 - Transform Vue JSX
 - Transform `generator` and `async/await`
 
@@ -34,6 +34,17 @@ Default: `false`
 Disable runtime transform. i.e. do not add helpers and polyfill for unsupported features of target environment, eg: `Object.assign`, `Promise`
 
 As we're using `babel-plugin-transform-runtime` to polyfill your code without polluting globals, something like `"foobar".includes("foo")` will not work since that would require modification of existing builtins. See [babel-plugin-transform-runtime](https://www.npmjs.com/package/babel-plugin-transform-runtime).
+
+### envTargets
+
+Type: `object`<br>
+Default: `{ ie: 9, uglify: true }`
+
+Takes an object of environment versions to support.
+
+As we're using `babel-preset-env` to determine the Babel plugins and polyfills you need, this option lets you adjust your supported environments. See `targets` in [babel-plugin-preset-env](https://www.npmjs.com/package/babel-preset-env).
+
+Note: when env is "test" `targets` is always `{ node: 'current' }`.
 
 ## Contributing
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,13 +2,11 @@ import path from 'path'
 
 export default function (context, {
   useBuiltIns,
-  targets
-} = {
-  targets: {
+  targets = {
     ie: 9,
     uglify: true
   }
-}) {
+} = {}) {
   const env = process.env.BABEL_ENV || process.env.NODE_ENV
 
   const presets = [

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,14 @@
 import path from 'path'
 
 export default function (context, {
-  useBuiltIns
-} = {}) {
+  useBuiltIns,
+  envTargets
+} = {
+  envTargets: {
+    ie: 9,
+    uglify: true
+  }
+}) {
   const env = process.env.BABEL_ENV || process.env.NODE_ENV
 
   const presets = [
@@ -15,10 +21,7 @@ export default function (context, {
     [require('babel-preset-env').default, {
       useBuiltIns,
       modules: false,
-      targets: {
-        ie: 9,
-        uglify: true
-      }
+      targets: envTargets
     }],
     // vue jsx
     require.resolve('babel-preset-vue')

--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,9 @@ import path from 'path'
 
 export default function (context, {
   useBuiltIns,
-  envTargets
+  targets
 } = {
-  envTargets: {
+  targets: {
     ie: 9,
     uglify: true
   }
@@ -21,7 +21,7 @@ export default function (context, {
     [require('babel-preset-env').default, {
       useBuiltIns,
       modules: false,
-      targets: envTargets
+      targets
     }],
     // vue jsx
     require.resolve('babel-preset-vue')

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -39,3 +39,11 @@ test('generator function', async () => {
   expect(actual).toMatch('import _regeneratorRuntime from')
   expect(actual).not.toMatch('function * foo()')
 })
+
+test('envTargets', async () => {
+  const input = await fs.readFile('./fixture/async-function.js', 'utf8')
+  const actual = transform(input, { envTargets: { node: '8.4' } })
+  expect(actual).not.toMatch('import _regeneratorRuntime from')
+  expect(actual).not.toMatch('import _asyncToGenerator from')
+  expect(actual).toMatch('async function')
+})

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -40,9 +40,9 @@ test('generator function', async () => {
   expect(actual).not.toMatch('function * foo()')
 })
 
-test('envTargets', async () => {
+test('targets', async () => {
   const input = await fs.readFile('./fixture/async-function.js', 'utf8')
-  const actual = transform(input, { envTargets: { node: '8.4' } })
+  const actual = transform(input, { targets: { node: '8.4' } })
   expect(actual).not.toMatch('import _regeneratorRuntime from')
   expect(actual).not.toMatch('import _asyncToGenerator from')
   expect(actual).toMatch('async function')


### PR DESCRIPTION
Given the primary feature of `babel-preset-env` is "a Babel preset that can automatically determine the Babel plugins and polyfills you need based on your supported environments," it makes sense to me to be able to adjust the targeted environments of `babel-preset-vue-app` to something newer than ES5.

This PR exposes the `targets` as an option in this preset, so we can do things like disable async transformations if we want to use the native browser support for such features.

One aspect of this PR that I am on the fence about is whether or not the new option should also override the targets when env is "test", as the original implementation has a special case here.  I've opted to be conservative and leave the special "test" case in place. Please let me know if you want it otherwise.

Thanks!
