### PR TITLE
Always transform helpers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ export default function (context, {
   const plugins = [
     // Polyfills the runtime needed for async/await and generators
     [require.resolve('babel-plugin-transform-runtime'), {
-      helpers: !useBuiltIns,
+      helpers: true,
       polyfill: !useBuiltIns,
       regenerator: true,
       // Resolve the Babel runtime relative to the config.


### PR DESCRIPTION
Helpers are transformed to save space and doesn't relate to the polyfill.